### PR TITLE
Feat : develop recommand & category

### DIFF
--- a/Back-End/src/main/java/com/dongne/its/base/apiPayload/code/status/ErrorStatus.java
+++ b/Back-End/src/main/java/com/dongne/its/base/apiPayload/code/status/ErrorStatus.java
@@ -18,14 +18,16 @@ public enum ErrorStatus implements BaseErrorCode {
     // Member Error
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, 4001, "사용자가 없습니다."),
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, 4002, "닉네임은 필수 입니다."),
-    PERMISSION_DENY(HttpStatus.BAD_REQUEST, 4003, "권한이 없습니다.");
+    PERMISSION_DENY(HttpStatus.BAD_REQUEST, 4003, "권한이 없습니다."),
 
     // Project Error
 
     // Issue Error
+    CATEGORY_NOT_MATCH(HttpStatus.BAD_REQUEST,4004,"검색 카테고리가 올바르지 않습니다.")
 
     // Comment Error
 
+;
     private final HttpStatus httpStatus;
     private final Integer code;
     private final String message;

--- a/Back-End/src/main/java/com/dongne/its/issue/converter/IssueConverter.java
+++ b/Back-End/src/main/java/com/dongne/its/issue/converter/IssueConverter.java
@@ -2,6 +2,7 @@ package com.dongne.its.issue.converter;
 
 import com.dongne.its.issue.domain.Issue;
 import com.dongne.its.issue.web.dto.IssueCreateRequestDto;
+import com.dongne.its.issue.web.dto.IssueRecommendResponseDto;
 import com.dongne.its.issue.web.dto.IssueResponseDto;
 import com.dongne.its.member.converter.MemberConverter;
 import java.util.List;
@@ -42,6 +43,26 @@ public class IssueConverter {
         .category(issue.getCategory())
 //        .comments(CommentConverter.toCommentResponseDto(issue.getComments()))
         .isDeleted(issue.isDeleted())
+        .build()).toList();
+  }
+
+  public static IssueRecommendResponseDto toIssueRecommendResponseDto(IssueResponseDto issueResponseDto, Long score){
+    if(issueResponseDto == null) return null;
+
+    return IssueRecommendResponseDto.builder()
+        .issueResponseDto(issueResponseDto)
+        .score(score)
+        .isDeleted(false)
+        .build();
+  }
+
+  public static List<IssueRecommendResponseDto> toListIssueRecommendResponseDto(List<IssueRecommendResponseDto> recommends){
+    if(recommends == null || recommends.isEmpty()) return null;
+
+    return recommends.stream().map(recommend -> IssueRecommendResponseDto.builder()
+        .issueResponseDto(recommend.getIssueResponseDto())
+        .score(recommend.getScore())
+        .isDeleted(recommend.getIsDeleted())
         .build()).toList();
   }
 

--- a/Back-End/src/main/java/com/dongne/its/issue/service/IssueQueryService.java
+++ b/Back-End/src/main/java/com/dongne/its/issue/service/IssueQueryService.java
@@ -2,6 +2,7 @@ package com.dongne.its.issue.service;
 
 import com.dongne.its.issue.domain.Issue;
 
+import com.dongne.its.issue.web.dto.IssueRecommendResponseDto;
 import java.util.List;
 
 public interface IssueQueryService {
@@ -16,11 +17,11 @@ public interface IssueQueryService {
 
   List<Issue> findDevByProjectId(Long id);
 
-  List<Issue> search(Long id, String category, Long projectId, String keyword);
+  List<Issue> search(String category, Long projectId, String keyword);
 
-  List<Issue> recommend(Long id, Long issueId);
+  List<IssueRecommendResponseDto> recommend(Long issueId);
 
-  List<Issue> deleteFind(Long id);
+  List<Issue> deleteFind();
 
-  List<Issue> all(Long id);
+  List<Issue> all();
 }

--- a/Back-End/src/main/java/com/dongne/its/issue/service/IssueQueryServiceImpl.java
+++ b/Back-End/src/main/java/com/dongne/its/issue/service/IssueQueryServiceImpl.java
@@ -1,9 +1,15 @@
 package com.dongne.its.issue.service;
 
+import com.dongne.its.base.apiPayload.code.BaseErrorCode;
+import com.dongne.its.base.apiPayload.code.status.ErrorStatus;
+import com.dongne.its.base.apiPayload.exception.handler.GeneralExceptionHandler;
 import com.dongne.its.issue.apiPayload.code.status.IssueErrorStatus;
 import com.dongne.its.issue.apiPayload.exception.handler.IssueHandler;
 import com.dongne.its.issue.domain.Issue;
+import com.dongne.its.issue.domain.enums.Priority;
+import com.dongne.its.issue.domain.enums.Status;
 import com.dongne.its.issue.repository.IssueRepository;
+import com.dongne.its.issue.web.dto.IssueRecommendResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -28,43 +34,52 @@ public class IssueQueryServiceImpl implements IssueQueryService{
 
   @Override
   public List<Issue> findIssueByProjectId(Long id) {
-    return null;
-    //return issueRepository.findIssueByProjectId(id);
+    return issueRepository.findIssueByProjectId(id);
   }
 
   @Override
   public List<Issue> findTesterByProjectId(Long id) {
-    return null;
-    //return issueRepository.findTesterByProjectId(id);
+    return issueRepository.findTesterByProjectId(id);
   }
 
   @Override
   public List<Issue> findDevByProjectId(Long id) {
-    return null;
-    //return issueRepository.findDevByProjectId(id);
+    return issueRepository.findDevByProjectId(id);
   }
 
   @Override
-  public List<Issue> search(Long id, String category, Long projectId, String keyword) {
-    return null;
-    //return issueRepository.search(id, category, projectId, keyword);
+  public List<Issue> search(String category, Long projectId, String keyword) {
+    switch(category){
+      case "TITLE":
+        return issueRepository.titleSearch(projectId, keyword);
+      case "STATUS":
+        return issueRepository.statusSearch(projectId, Status.valueOf(keyword));
+      case "PRIORITY":
+        return issueRepository.prioritySearch(projectId, Priority.valueOf(keyword));
+      case "ASSIGNEE":
+        return issueRepository.assigneeSearch(projectId, keyword);
+      default:
+        throw new GeneralExceptionHandler(ErrorStatus.CATEGORY_NOT_MATCH);
+
+    }
   }
 
   @Override
-  public List<Issue> recommend(Long id, Long issueId) {
-    return null;
-    //return issueRepository.recommend(id, issueId);
+  public List<IssueRecommendResponseDto> recommend(Long issueId) {
+    List<Issue> issues = issueRepository.recommend(issueId);
+    //
+
+    List<IssueRecommendResponseDto> top3Score = null;
+    return top3Score;
   }
 
   @Override
-  public List<Issue> deleteFind(Long id) {
-    return null;
-    //return issueRepository.deleteFind(id);
+  public List<Issue> deleteFind() {
+    return issueRepository.deleteFind();
   }
 
   @Override
-  public List<Issue> all(Long id) {
-    return null;
-    //return issueRepository.all(id);
+  public List<Issue> all() {
+    return issueRepository.all();
   }
 }

--- a/Back-End/src/main/java/com/dongne/its/issue/web/controller/IssueController.java
+++ b/Back-End/src/main/java/com/dongne/its/issue/web/controller/IssueController.java
@@ -11,6 +11,7 @@ import com.dongne.its.issue.web.dto.IssueAssignRequestDto;
 import com.dongne.its.issue.web.dto.IssueCreateRequestDto;
 import com.dongne.its.issue.web.dto.IssueDeleteRequestDto;
 import com.dongne.its.issue.web.dto.IssueExceptionDto;
+import com.dongne.its.issue.web.dto.IssueRecommendResponseDto;
 import com.dongne.its.issue.web.dto.IssueResponseDto;
 import com.dongne.its.issue.web.dto.IssueStatusUpdateRequestDto;
 import com.dongne.its.issue.web.dto.IssueUpdateRequestDto;
@@ -108,25 +109,25 @@ public class IssueController {
 
   @GetMapping("/search")
   public ResponseEntity<List<IssueResponseDto>> search(@RequestHeader("id") Long id, @RequestParam("category") String category, @RequestParam("projectId") Long projectId, @RequestParam("keyword") String keyword){
-    List<Issue> issues_target = issueQueryService.search(id, category, projectId, keyword);
+    List<Issue> issues_target = issueQueryService.search(category, projectId, keyword);
     return ApiResponse.onSuccess(IssueConverter.toListIssueResponseDto(issues_target));
   }
 
   @GetMapping("/issueRecommend")
-  public ResponseEntity<List<IssueResponseDto>> recommend(@RequestHeader("id") Long id, @RequestParam("issueId") Long issueId){
-    List<Issue> issues_target = issueQueryService.recommend(id, issueId);
-    return ApiResponse.onSuccess(IssueConverter.toListIssueResponseDto(issues_target));
+  public ResponseEntity<List<IssueRecommendResponseDto>> recommend(@RequestHeader("id") Long id, @RequestParam("issueId") Long issueId){
+    List<IssueRecommendResponseDto> issues_target = issueQueryService.recommend(issueId);
+    return ApiResponse.onSuccess(IssueConverter.toListIssueRecommendResponseDto(issues_target));
   }
 
   @GetMapping("/deleteRequest/find")
   public ResponseEntity<List<IssueResponseDto>> deleteFind(@RequestParam("id") Long id){
-    List<Issue> issues_target = issueQueryService.deleteFind(id);
+    List<Issue> issues_target = issueQueryService.deleteFind();
     return ApiResponse.onSuccess(IssueConverter.toListIssueResponseDto(issues_target));
   }
 
   @GetMapping("/all")
   public ResponseEntity<List<IssueResponseDto>> all(@RequestHeader("id") Long id){
-    List<Issue> issues_target = issueQueryService.all(id);
+    List<Issue> issues_target = issueQueryService.all();
     return ApiResponse.onSuccess(IssueConverter.toListIssueResponseDto(issues_target));
   }
 


### PR DESCRIPTION
search에서 category별로 switch분기를 통해 새로 함수를 구성했습니다

recommend 껍데기 구현했습니다. 
controller에서의 변경을 통해 이제 recommend는 IssueRecommendResponseDto 리스트를 반환합니다.
IssueResponseDto는 IssueResponse + Long score 형태로, 개발자 추천도가 score가 되겠습니다.

현재 구상한 로직은 다음과 같습니다.
일단 쿼리문을 통해 프로젝트 내부의 이슈를 전부 서비스 함수 안에서 받아온 상태이므로, 
모든 이슈를 돌며 개발자를 특정해 개발자 리스트를 구성합니다. (중복이 없도록)
기준에 따라 스코어를 매기고, 개발자마다 IssueRecommendResponseDto를 생성합니다. 
여기서 들어가는 IssueResponse는 개발자 탐색 시 처음으로 마주한 것으로 처리하면 되지 않을까 싶습니다

순서
1. 긁어온 이슈를 한 번 돌리며 개발자(멤버) 탐색
2. 신규 개발자가 발견될 때 마다, 미리 만들어둔 이슈추천응답Dto 리스트에 하나씩 추가, 개발자를 발견한 이슈응답Dto를 삽입
score 0 점으로 해서 일단 리스트 만들고, 점수 산정 후 업데이트 하는 방식
3. 완성된 리스트 반환
4. 컨트롤러가 받아 클라이언트에게 전달